### PR TITLE
Use correct format of the manifest entry *_Plugin-Url

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -21,8 +21,8 @@
 
     <target name="additional-manifest">
         <manifest file="MANIFEST" mode="update">
-            <attribute name="13170_Plugin-Url" value="https://github.com/maripo/JOSM_quicklabel/releases/download/v1.6.1/QuickLabel.jar" />
-            <attribute name="12545_Plugin-Url" value="https://github.com/maripo/JOSM_quicklabel/releases/download/v1.0.1/QuickLabel.jar" />
+            <attribute name="13170_Plugin-Url" value="v1.6.1;https://github.com/maripo/JOSM_quicklabel/releases/download/v1.6.1/QuickLabel.jar" />
+            <attribute name="12545_Plugin-Url" value="v1.0.1;https://github.com/maripo/JOSM_quicklabel/releases/download/v1.0.1/QuickLabel.jar" />
         </manifest>
 	</target>
 	


### PR DESCRIPTION
See https://josm.openstreetmap.de/ticket/16400#comment:2 and the [documentation for the manifest entries](https://josm.openstreetmap.de/wiki/DevelopersGuide/DevelopingPlugins#ThemanifestfileforaJOSMplugin)
The version of the plugin must be provided before the URL separated with a semicolon